### PR TITLE
Expand invalid regex tests to cover error messages

### DIFF
--- a/test/modules/02-compilation.test.js
+++ b/test/modules/02-compilation.test.js
@@ -37,7 +37,7 @@ describe('Basic Pattern Compilation', () => {
 
   test('should reject invalid patterns', () => {
     try {
-      expect(() => pcre.compile('[')).toThrow();
+      expect(() => pcre.compile('[')).toThrow('PCRE compilation failed: missing terminating ] for character class at offset 1');
       // Note: (?P<>invalid) is valid in original libpcre but invalid in libpcre2
       // Since we're using original libpcre, we don't expect this to throw
       // expect(() => pcre.compile('(?P<>invalid)')).toThrow();

--- a/test/modules/13-error-handling.test.js
+++ b/test/modules/13-error-handling.test.js
@@ -18,7 +18,7 @@ describe('Error Handling and Edge Cases', () => {
     try {
       expect(() => {
         pcre.compile('[invalid');
-      }).toThrow();
+      }).toThrow('PCRE compilation failed: missing terminating ] for character class at offset 8');
     } catch (error) {
       console.error('FATAL ERROR in invalid regex test:', error);
       throw error;
@@ -42,10 +42,10 @@ describe('Error Handling and Edge Cases', () => {
       const regex = pcre.compile('test');
       expect(() => {
         regex.exec(null);
-      }).toThrow();
+      }).toThrow('Cannot pass non-string to std::string');
       expect(() => {
         regex.exec(undefined);
-      }).toThrow();
+      }).toThrow('Cannot pass non-string to std::string');
     } catch (error) {
       console.error('FATAL ERROR in null/undefined inputs test:', error);
       throw error;


### PR DESCRIPTION
resolves #1

I've just added the error message into existing `toThrow()`

I did notice that `toThrow()` only looks for the substring
so we could remove the `PCRE compilation failed: ` part of the message if wanted